### PR TITLE
Fix: length_limit in ROUGE evaluation

### DIFF
--- a/sumeval/metrics/lang/lang_en.py
+++ b/sumeval/metrics/lang/lang_en.py
@@ -8,6 +8,7 @@ class LangEN(BaseLang):
         super(LangEN, self).__init__("en")
         self._symbol_replace = re.compile(r"[^A-Za-z0-9-]")
         self._valid_word = re.compile(r"^[A-Za-z0-9$]")
+        self.space_length = 1
 
     def tokenize(self, text):
         _txt = self._format_text(text)
@@ -15,6 +16,9 @@ class LangEN(BaseLang):
         words = [w.strip() for w in words if w.strip()]
         words = [w for w in words if self._valid_word.match(w)]
         return words
+
+    def split(self, text):
+        return text.split()
 
     def _format_text(self, text):
         _txt = text.replace("-", " - ")

--- a/sumeval/metrics/lang/lang_ja.py
+++ b/sumeval/metrics/lang/lang_ja.py
@@ -8,6 +8,7 @@ class LangJA(BaseLang):
         super(LangJA, self).__init__("ja")
         self._set_tokenizer()
         self._symbol_replace = re.compile(r"[^ぁ-んァ-ン一-龥ーa-zA-Zａ-ｚＡ-Ｚ0-9０-９]")
+        self.space_length = 0
 
     def load_parser(self):
         if self._PARSER is None:
@@ -45,6 +46,9 @@ class LangJA(BaseLang):
         words = [t.surface for t in self.tokenizer.tokenize(_txt)]
         words = [w.strip() for w in words if w.strip()]
         return words
+
+    def split(self, text):
+        return self.tokenize(text)
 
     def parse_dependency_tree(self, text):
         _txt = self._symbol_replace.sub(" ", text)

--- a/sumeval/metrics/rouge.py
+++ b/sumeval/metrics/rouge.py
@@ -30,27 +30,29 @@ class RougeCalculator():
         https://github.com/andersjo/pyrouge/blob/master/tools/ROUGE-1.5.5/ROUGE-1.5.5.pl#L1820
         """
         words = text_or_words
-        # tokenization
-        if isinstance(words, str):
-            if self.tokenizer:
-                words = self.tokenizer.tokenize(text_or_words)
-            else:
-                words = self.lang.tokenize(text_or_words)
-
-        words = [w.strip().lower() for w in words if w.strip()]
 
         # limit length
         if self.word_limit > 0:
-            words = words[:self.word_limit]
-        elif self.length_limit > 0:
-            _words = []
-            length = 0
-            for w in words:
-                if length + len(w) < self.length_limit:
-                    _words.append(w)
+            if isinstance(words, str):
+                if self.tokenizer:
+                    words = self.tokenizer.split(text_or_words)
                 else:
-                    break
-            words = _words
+                    words = self.lang.split(text_or_words)
+            if self.word_limit < len(words):
+                words = words[:self.word_limit]
+            text = '{}'.format(' ' * self.lang.space_length).join(words)
+        else:
+            if not isinstance(words, str):
+                text = '{}'.join(' ' * self.lang.space_length).join(words)
+            else:
+                text = words
+
+            if self.length_limit > 0:
+                if self.length_limit < len(text):
+                    text = text[:self.length_limit]
+
+        text = text.lower()
+        words = self.lang.tokenize(text)
 
         if self.stopwords:
             words = [w for w in words if not self.lang.is_stop_word(w)]
@@ -62,7 +64,6 @@ class RougeCalculator():
             # min_length ref
             # https://github.com/andersjo/pyrouge/blob/master/tools/ROUGE-1.5.5/ROUGE-1.5.5.pl#L2629
             words = [self.lang.stemming(w, min_length=3) for w in words]
-
         return words
 
     def parse_to_be(self, text, is_reference=False):

--- a/tests/test_rouge.py
+++ b/tests/test_rouge.py
@@ -77,6 +77,31 @@ class TestRouge(unittest.TestCase):
                                 reference=[[[r] for r in references]],
                                 n_gram=n, recall_only=False,
                                 length_limit=True, length=50,
+                                word_level=False,
+                                stemming=False, stopwords=True)
+                    b1_v = baseline.calc_score()
+                    b2_v = rouge_n(rouge.tokenize(s),
+                                   [rouge.tokenize(r) for r in references],
+                                   n, 0.5)
+                    v = rouge.rouge_n(s, references, n)
+                    self.assertLess(abs(b2_v - v), 1e-5)
+                    self.assertLess(abs(b1_v["ROUGE-{}-F".format(n)] - v), 1e-5) # noqa
+
+    def test_rouge_with_word_limit(self):
+        data = self.load_test_data()
+        rouge = RougeCalculator(stopwords=True, word_limit=5)
+        for eval_id in data:
+            summaries = data[eval_id]["summaries"]
+            references = data[eval_id]["references"]
+            for n in [1, 2]:
+                for s in summaries:
+                    baseline = Pythonrouge(
+                                summary_file_exist=False,
+                                summary=[[s]],
+                                reference=[[[r] for r in references]],
+                                n_gram=n, recall_only=False,
+                                length_limit=True, length=5,
+                                word_level=True,
                                 stemming=False, stopwords=True)
                     b1_v = baseline.calc_score()
                     b2_v = rouge_n(rouge.tokenize(s),


### PR DESCRIPTION
Problems I found and fixed:

- Summaries are not truncated when `length_limit` ( > 0) is given.
- Preprocessing of text before truncating is a bit different from original ROUGE script.
- In test code, `pyrouge` truncates summaries with the number of words while `sumeval` truncates them with the number of characters.

This PR was tested with `nosetests -s ./tests/test_rouge.py`.

