### PR TITLE
Add measure options for recall and precision in ROUGE

### DIFF
--- a/sumeval/cli/sum_eval.py
+++ b/sumeval/cli/sum_eval.py
@@ -13,6 +13,7 @@ def main(
     stemming: ("use stemming", "flag", "st"),
     word_limit: ("word limit count", "option", "wl") = -1,
     length_limit: ("sentence limit length", "option", "ll") = -1,
+    measure: ("measuring method of score in ROUGE", "option", "mm") = 'f1',
     alpha: ("alpha for f1-score", "option") = 0.5,
     language: ("word limit count", "option", "la") = "en",
     *params):
@@ -57,7 +58,7 @@ def main(
         scorer = RougeCalculator(
             stopwords=stopwords, stemming=stemming,
             word_limit=word_limit, length_limit=length_limit,
-            lang=language)
+            measure=measure, lang=language)
 
         for s, rs in generator:
             score = {}

--- a/sumeval/cli/sum_eval.py
+++ b/sumeval/cli/sum_eval.py
@@ -13,7 +13,7 @@ def main(
     stemming: ("use stemming", "flag", "st"),
     word_limit: ("word limit count", "option", "wl") = -1,
     length_limit: ("sentence limit length", "option", "ll") = -1,
-    measure: ("measuring method of score in ROUGE", "option", "mm") = 'f1',
+    measure: ("measuring method of score in ROUGE", "option", "mm") = "f1",
     alpha: ("alpha for f1-score", "option") = 0.5,
     language: ("word limit count", "option", "la") = "en",
     *params):

--- a/sumeval/metrics/rouge.py
+++ b/sumeval/metrics/rouge.py
@@ -132,7 +132,8 @@ class RougeCalculator():
         Returns
         -------
         score: float
-            measured score
+            Measured score. The way of measuring is specified by self.measure
+            and should be one of the recall, precision, f1
         """
         _summary = self.tokenize(summary)
         summary_ngrams = self.count_ngrams(_summary, n)

--- a/tests/test_sum_eval.py
+++ b/tests/test_sum_eval.py
@@ -14,6 +14,7 @@ class TestSumEval(unittest.TestCase):
                 False,
                 -1,
                 -1,
+                "f1",
                 0.5,
                 "en",
                 "I'm living New York its my home town so awesome",


### PR DESCRIPTION
This module always returned f1 score but in some cases, we want to know the score based on the other measuring method (ex. recall) when using ROUGE.
Then, I implemented a measure option for specifying the way of calculating a score.

This PR was passed `test_rouge.py` and `test_rouge_ja.py`.