### PR TITLE
limit sacrebleu version < 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ pip install sumeval
 
 ## Dependencies
 
-* BLEU is depends on [SacréBLEU](https://github.com/awslabs/sockeye/tree/master/contrib/sacrebleu)
+* BLEU is depends on [SacréBLEU](https://github.com/mjpost/sacrebleu)
 * To calculate `ROUGE-BE`, [`spaCy`](https://github.com/explosion/spaCy) is required.
 * To use lang `ja`, [`janome`](https://github.com/mocobeta/janome) or [`MeCab`](https://github.com/taku910/mecab) is required.
   * Especially to get score of `ROUGE-BE`, [`GiNZA`](https://github.com/megagonlabs/ginza) is needed additionally.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 plac>=0.9.6
-sacrebleu>=1.3.2
+sacrebleu>=1.3.2,<2.0.0


### PR DESCRIPTION
I happened to find that `sacrebleu` v2.0.0 has breaking changes, which causes `ImportError` when using `BLEUCalculator`:

```
>>> from sumeval.metrics.bleu import BLEUCalculator
---------------------------------------------------------------------------
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File ~/myproject/.venv/lib/python3.8/site-packages/sumeval/metrics/bleu.py:1, in <module>
    from sacrebleu import corpus_bleu, TOKENIZERS, DEFAULT_TOKENIZER
ImportError: cannot import name 'TOKENIZERS' from 'sacrebleu' (/home/myuser/myproject/.venv/lib/python3.8/site-packages/sacrebleu/__init__.py)
```

A possible first aid could be to force users to use `sacrebleu` below v2.0.0, just a temporary measure though.

I have also fixed a broken link in README.md.